### PR TITLE
Update MulticolorLayout.java

### DIFF
--- a/jcabi-log/src/main/java/com/jcabi/log/MulticolorLayout.java
+++ b/jcabi-log/src/main/java/com/jcabi/log/MulticolorLayout.java
@@ -113,16 +113,16 @@ public final class MulticolorLayout extends PatternLayout {
     /**
      * Colors of levels.
      */
-    private static final ConcurrentMap<Level, String> LEVELS =
-        new ConcurrentHashMap<Level, String>() {
+    private static final ConcurrentMap<String, String> LEVELS =
+        new ConcurrentHashMap<String, String>() {
             private static final long serialVersionUID = 0x7526FF78EEDFC465L;
             {
-                this.put(Level.TRACE, "2;33");
-                this.put(Level.DEBUG, "2;37");
-                this.put(Level.INFO, "0;37");
-                this.put(Level.WARN, "0;33");
-                this.put(Level.ERROR, "0;31");
-                this.put(Level.FATAL, "0;35");
+                this.put(Level.TRACE.toString(), "2;33");
+                this.put(Level.DEBUG.toString(), "2;37");
+                this.put(Level.INFO.toString(), "0;37");
+                this.put(Level.WARN.toString(), "0;33");
+                this.put(Level.ERROR.toString(), "0;31");
+                this.put(Level.FATAL.toString(), "0;35");
             }
         };
 
@@ -163,7 +163,7 @@ public final class MulticolorLayout extends PatternLayout {
             String.format(
                 "%s%sm",
                 MulticolorLayout.CSI,
-                MulticolorLayout.LEVELS.get(event.getLevel())
+                MulticolorLayout.LEVELS.get(event.getLevel().toString())
             )
         );
     }


### PR DESCRIPTION
На моем окружении LoggingEvent.getLevel() имеют hashCode(), не совпадающий ни с одним ключом в мапе LEVELS, при том, что они равны с ними по equals().
Предлагаю вариант, как это исправить.

На всякий случай параметры моего окружения:
uname -a
Linux antares 3.5.0-25-generic #39-Ubuntu SMP Mon Feb 25 18:26:58 UTC 2013 x86_64 x86_64 x86_64 GNU/Linux

java -version
java version "1.7.0_17"
Java(TM) SE Runtime Environment (build 1.7.0_17-b02)
Java HotSpot(TM) 64-Bit Server VM (build 23.7-b01, mixed mode)

log4j-1.2.17.jar
