### PR TITLE
Fixed an issue where AspectJ woven classes could not be proxied for dependency injection by CDI Weld.

### DIFF
--- a/jcabi-maven-plugin/src/main/java/com/jcabi/maven/plugin/AjcMojo.java
+++ b/jcabi-maven-plugin/src/main/java/com/jcabi/maven/plugin/AjcMojo.java
@@ -157,6 +157,7 @@ public final class AjcMojo extends AbstractMojo {
         final String jdk = "1.6";
         main.run(
             new String[] {
+                "-Xset:avoidFinal=true",
                 "-inpath",
                 this.classesDirectory.getAbsolutePath(),
                 "-sourceroots",


### PR DESCRIPTION
For more information refer 
https://bugs.eclipse.org/bugs/show_bug.cgi?id=349149

Can you please put it into a release? We have an policy to not depend on external SNAPSHOT repos. Also, let me know if I could have solved it by using aspectj-maven-plugin.

Thanks. 
