### PR TITLE
fix test assertion because of missing standalone definition in xml heade...

### DIFF
--- a/jcabi-log/src/main/java/com/jcabi/log/DomDecor.java
+++ b/jcabi-log/src/main/java/com/jcabi/log/DomDecor.java
@@ -94,6 +94,7 @@ final class DomDecor implements Formattable {
             try {
                 final Transformer trans = DomDecor.FACTORY.newTransformer();
                 trans.setOutputProperty(OutputKeys.INDENT, "yes");
+                trans.setOutputProperty(OutputKeys.STANDALONE, "no");
                 trans.transform(
                     new DOMSource(this.node),
                     new StreamResult(writer)


### PR DESCRIPTION
Hi, i want to adjust your MulticolorLayout and forked. I use JDK 7 and there seam to be a small change in javax.xml.transform.Transformer handling the xml header. It omits the standalone attribute. So it force to add it. 
