### PR TITLE
fix assertion fail because of different decimal separator symbols in dif...

### DIFF
--- a/jcabi-log/src/test/java/com/jcabi/log/AbstractDecorTest.java
+++ b/jcabi-log/src/test/java/com/jcabi/log/AbstractDecorTest.java
@@ -86,6 +86,7 @@ public abstract class AbstractDecorTest {
         this.flags = flgs;
         this.width = wdt;
         this.precision = prcs;
+        Locale.setDefault(Locale.US);
     }
 
     /**


### PR DESCRIPTION
I am from germany and my mac is configured to formate numbers in german layout ;-) We in germany use the ',' inside a decimal number e.g. pi looks like 3,14159265359! So the test for jacobi-log fail. The simplest way to fix this was to force the used locale used in test to be US. 
