### PR TITLE
extend org.apache.log4j.EnhancedPatternLayout

### DIFF
--- a/jcabi-log/src/main/java/com/jcabi/log/MulticolorLayout.java
+++ b/jcabi-log/src/main/java/com/jcabi/log/MulticolorLayout.java
@@ -36,6 +36,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
+import org.apache.log4j.EnhancedPatternLayout;
 import org.apache.log4j.Level;
 import org.apache.log4j.PatternLayout;
 import org.apache.log4j.spi.LoggingEvent;
@@ -85,7 +86,7 @@ import org.apache.log4j.spi.LoggingEvent;
 @ToString
 @EqualsAndHashCode(callSuper = false)
 @SuppressWarnings("PMD.NonStaticInitializer")
-public final class MulticolorLayout extends PatternLayout {
+public final class MulticolorLayout extends EnhancedPatternLayout {
 
     /**
      * Control sequence indicator.


### PR DESCRIPTION
If MulticolorLayout extends EnhancedPatternLayout the layout can be more flexible. e.g. positioning the stack-trace and even color it. 
