### PR TITLE
add maven-bundle-plugin to make jcabi projects valid OSGI bundles

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -146,6 +146,12 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <version>3.0.0</version>
+                <extensions>true</extensions>
+            </plugin>
         </plugins>
     </build>
 </project>


### PR DESCRIPTION
Configure maven-bundle-plugin in this parent pom, so that we could easily turn any jcabi project into bundle later.
N.B: I tried to use the last version of this parent into jcabi/jcabi-log but there are compilation error because of the new version of Mockito.
